### PR TITLE
Replace through1 to through2/v1(Stream3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-mongoose-write-stream
-=====================
+mongoose-write-stream-th2
+=========================
 
-Super simple mongoose plugin that adds writable streams to your models.
+Super simple mongoose plugin that adds writable streams to your models using [through2@1](https://github.com/rvagg/through2/tree/v1.0).
 
 ## Example
 
@@ -12,7 +12,7 @@ var request  = require('request');
 var zlib     = require('zlib');
 
 mongoose.connect('mongodb://127.0.0.1:27017/example');
-mongoose.plugin(require('mongoose-write-stream'));
+mongoose.plugin(require('mongoose-write-stream-th2'));
 
 var Tick = mongoose.model('Tick', {
   time: Number,

--- a/index.js
+++ b/index.js
@@ -1,14 +1,16 @@
-var through = require('through');
+var through = require('through2');
 
 module.exports = function(schema, options) {
-  schema.static('writeStream', function() {
-    var model = this;
-    return through(function(data) {
-      var stream = this;
-      model.create(data, function(err, res) {
-        err ? stream.emit('error', err)
-            : stream.emit('data', data);
-      });
+    schema.static('writeStream', function() {
+        var model = this;
+        return through.obj(function(data, enc, cb) {
+            var stream = this;
+            model.create(data, function(err, res) {
+                if (!err) {
+                    stream.push(data);
+                }
+                cb(err);
+            });
+        });
     });
-  });
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mongoose-write-stream",
+  "name": "mongoose-write-stream-th2",
   "version": "0.0.0",
   "description": "",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ashaffer/mongoose-write-stream.git"
+    "url": "https://github.com/kuronekomichael/mongoose-write-stream-th2.git"
   },
   "keywords": [
     "mongoose",
@@ -17,15 +17,17 @@
     "stream",
     "mongoose",
     "write",
-    "stream"
+    "stream",
+    "stream3",
+    "through2"
   ],
-  "author": "ashaffer",
+  "author": "ashaffer featuring kuronekomichael",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ashaffer/mongoose-write-stream/issues"
+    "url": "https://github.com/kuronekomichael/mongoose-write-stream-th2/issues"
   },
-  "homepage": "https://github.com/ashaffer/mongoose-write-stream",
+  "homepage": "https://github.com/kuronekomichael/mongoose-write-stream-th2",
   "dependencies": {
-    "through": "^2.3.4"
+    "through2": ">=1.0.0"
   }
 }


### PR DESCRIPTION
[mongoose](http://mongoosejs.com/)の便利なプラグインなので、ちょこっと改修しました。
- 任意の数のモデルを全て書き込み完了したタイミングを拾えなかったので、  
  `on("end")`で拾えるようにしました
- ついでにStream3に対応するため、[through2](https://github.com/rvagg/through2/tree/v1.0)のv1.0を使うことにしました
